### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/shelkeaniketTestOrganization02/23c3d6cd-2f80-4dea-a8ad-50fa9d186986/2425a344-cb9f-4dbf-82a8-e43b440050fc/_apis/work/boardbadge/c94c4cd3-33b2-4c05-a337-644059e8d750)](https://dev.azure.com/shelkeaniketTestOrganization02/23c3d6cd-2f80-4dea-a8ad-50fa9d186986/_boards/board/t/2425a344-cb9f-4dbf-82a8-e43b440050fc/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/shelkeaniketTestOrganization02/23c3d6cd-2f80-4dea-a8ad-50fa9d186986/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.